### PR TITLE
Add Docker Scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please add a note of your changes below this heading if you make a Pull Request.
 * Unit Testing with Doctest has been started for select algorithms, see [Firmware/Tests/test_runner.cpp](Firmware/Tests/test_runner.cpp)
 * Added support for Flylint VSCode Extension for static code analysis
 * Using an STM32F405 .svd file allows CortexDebug to view registers during debugging
+* Added scripts for building via docker.
 
 ### Changed
 * Changed ratiometric `motor.config.current_lim_tolerance` to absolute `motor.config.current_lim_margin`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu
+
+# Prepare the build environment and dependencies
+RUN apt-get update
+RUN apt-get -y install software-properties-common
+RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa
+RUN add-apt-repository ppa:jonathonf/tup
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get -y install gcc-arm-embedded openocd tup python3.7 build-essential git
+
+# Build step below does not know about debian's python naming schemme
+RUN ln -s /usr/bin/python3.7 /usr/bin/python
+
+# Copy the firmware tree into the container
+RUN mkdir ODrive
+COPY . ODrive
+WORKDIR ODrive/Firmware
+
+# Hack around Tup's dependency on FUSE
+RUN tup generate build.sh
+RUN ./build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:bionic
 
 # Prepare the build environment and dependencies
 RUN apt-get update

--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -1,12 +1,12 @@
 function cleanup {
     echo "Removing previous build artifacts"
     rm -rf build
-    docker rm build-cont
+    docker rm odrive-build-cont
 }
 
 function gc {
     cleanup
-    docker rmi build-img
+    docker rmi odrive-build-img
     docker image prune
 }
 
@@ -14,17 +14,17 @@ function build {
     cleanup
 
     echo "Building the firmware"
-    docker build -t build-img .
+    docker build -t odrive-build-img .
 
     echo "Create container"
-    docker create --name build-cont build-img:latest
+    docker create --name odrive-build-cont odrive-build-img:latest
 
     echo "Extract build artifacts"
-    docker cp build-cont:ODrive/Firmware/build .
+    docker cp odrive-build-cont:ODrive/Firmware/build .
 }
 
 function usage {
-    echo "usage: $0 build | cleanup | gc"
+    echo "usage: $0 (build | cleanup | gc)"
     echo
     echo "build   -- build in docker and extract the artifacts."
     echo "cleanup -- remove build artifacts from previous build"

--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -1,0 +1,47 @@
+function cleanup {
+    echo "Removing previous build artifacts"
+    rm -rf build
+    docker rm build-cont
+}
+
+function gc {
+    cleanup
+    docker rmi build-img
+    docker image prune
+}
+
+function build {
+    cleanup
+
+    echo "Building the firmware"
+    docker build -t build-img .
+
+    echo "Create container"
+    docker create --name build-cont build-img:latest
+
+    echo "Extract build artifacts"
+    docker cp build-cont:ODrive/Firmware/build .
+}
+
+function usage {
+    echo "usage: $0 build | cleanup | gc"
+    echo
+    echo "build   -- build in docker and extract the artifacts."
+    echo "cleanup -- remove build artifacts from previous build"
+    echo "gc      -- remove all build images and containers"
+}
+
+case $1 in
+    build)
+	build
+	;;
+    cleanup)
+	cleanup
+	;;
+    gc)
+	gc
+	;;
+    *)
+	usage
+	;;
+esac


### PR DESCRIPTION
This is to lower the barrier of entry for compiling ODrive firmware. It constructs a build environment from the recommended Ubuntu base image, automatically fetching build dependencies. The included script will build and extract the firmware binaries into the project root.

* Run `./dockerbuild.sh build` to build the firmware.
* Run `./dockerbuild.sh gc` to clean up build containers.

Screenshot below -- unfortunately the build output is far too verbose to capture all of it in a screen shot, but note the build directory at the top-level, which is extracted from the container.

![image](https://user-images.githubusercontent.com/11739/73874385-4868fe00-4808-11ea-9eb0-2657caa20f1a.png)

