### PR TITLE
Wrap console.runcode calls in async coroutines to ensure they are awaited

### DIFF
--- a/Firmware/fibre/python/fibre/shell.py
+++ b/Firmware/fibre/python/fibre/shell.py
@@ -2,6 +2,7 @@
 import sys
 import platform
 import threading
+import asyncio
 import fibre
 
 def did_discover_device(device,
@@ -101,12 +102,12 @@ def launch_shell(args,
         interact = lambda: console.interact(banner='')
 
     # install hook to hide ChannelBrokenException
-    console.runcode('import sys')
-    console.runcode('superexcepthook = sys.excepthook')
-    console.runcode('def newexcepthook(ex_class,ex,trace):\n'
+    asyncio.run(console.runcode('import sys'))
+    asyncio.run(console.runcode('superexcepthook = sys.excepthook'))
+    asyncio.run(console.runcode('def newexcepthook(ex_class,ex,trace):\n'
                     '  if ex_class.__module__ + "." + ex_class.__name__ != "fibre.ChannelBrokenException":\n'
-                    '    superexcepthook(ex_class,ex,trace)')
-    console.runcode('sys.excepthook=newexcepthook')
+                    '    superexcepthook(ex_class,ex,trace)'))
+    asyncio.run(console.runcode('sys.excepthook=newexcepthook'))
 
 
     # Launch shell


### PR DESCRIPTION
I used asyncio to wrap the console.runcode calls. This runs them as coroutines and waits for each to return before continuing.
This PR should fix the RuntimeWarning: coroutine ... was never awaited errors when running the dev version of odrivetool.

Here are some screenshots for context:
Errors:
<img width="1037" alt="Screen Shot 2020-06-08 at 22 08 44 PM" src="https://user-images.githubusercontent.com/11552499/84101954-c31f7100-a9d4-11ea-8857-913004c85e77.png">
No errors:
<img width="366" alt="Screen Shot 2020-06-08 at 22 08 52 PM" src="https://user-images.githubusercontent.com/11552499/84101951-c286da80-a9d4-11ea-9b8b-5fcb3a45ffde.png">
